### PR TITLE
change .dev to .develop

### DIFF
--- a/_docs/components/requests.md
+++ b/_docs/components/requests.md
@@ -336,7 +336,7 @@ The `hasAccess` function, checks if the passed URL ID is the same as the User ID
 
 Example:
 
-Let's say we have an endpoint `www.api.apiato.dev/v1/users/{ID}/delete` that deletes a user. And we only need users to delete their own user accounts.
+Let's say we have an endpoint `www.api.apiato.develop/v1/users/{ID}/delete` that deletes a user. And we only need users to delete their own user accounts.
 
 With `isOwner`, user of ID 1 can only call `/users/1/delete` and won't be able to call `/users/2/delete` or any other ID.
 

--- a/_docs/features/admin-dashboard.md
+++ b/_docs/features/admin-dashboard.md
@@ -18,17 +18,17 @@ order: 110
 
 ## The provided Admin route
 
-- http://admin.apiato.dev/dashboard
+- http://admin.apiato.develop/dashboard
 
-- http://admin.apiato.dev/login
+- http://admin.apiato.develop/login
 
-- http://admin.apiato.dev/logout
+- http://admin.apiato.develop/logout
 
 <a name="how-it-works"></a>
 
 ## How it works
 
-Visiting `http://admin.apiato.dev/dashboard` will redirect you to a login page for admins.
+Visiting `http://admin.apiato.develop/dashboard` will redirect you to a login page for admins.
 
 the default credentials are:
 

--- a/_docs/features/api-docs-generator.md
+++ b/_docs/features/api-docs-generator.md
@@ -103,9 +103,9 @@ php artisan apiato:docs
 
 #### 3 - Visit this URL's as shown in your terminal:
 
-- Public (external) API at `http://apiato.dev/api/documentation/`
+- Public (external) API at `http://apiato.develop/api/documentation/`
 
-- Private (internal) API at `http://apiato.dev/api/private/documentation/`.
+- Private (internal) API at `http://apiato.develop/api/private/documentation/`.
 
 **NOTE:** Every time you do changes in the DocBlock of the Routes file you need to run this command.
 
@@ -190,7 +190,7 @@ Apiato generates by defaults 2 API documentations, each one has it's own `apidoc
   "description": "Apiato (Private API) Documentation",
   "title": "Welcome to Apiato",
   "version": "1.0.0",
-  "url" : "http://api.apiato.dev",
+  "url" : "http://api.apiato.develop",
   "template": {
     "withCompare": true,
     "withGenerator": true

--- a/_docs/features/authentication.md
+++ b/_docs/features/authentication.md
@@ -53,27 +53,32 @@ $router->get('secret/info', [
 
 All Endpoints protected with `auth:api` are accessible only when sending them a valid access token.
 
-This Middleware is provided by the [Laravel Passport](https://laravel.com/docs/passport) package. So you can read its documentation for more details.
+This Middleware is provided by the [Laravel Passport](https://laravel.com/docs/passport) package. So you can read its 
+documentation for more details.
 
 
 <a name="how-to-get-access-token-using-oauth-20"></a>
 ## How to get Access Token using OAuth 2.0
 
-All the Auth Endpoints are documented. Go to [Documentation Generator Page]({{ site.baseurl }}{% link _docs/features/api-docs-generator.md %}) to see how you can generate the API documentation, and read them.
+All the Auth Endpoints are documented. Go to [Documentation Generator Page]({{ site.baseurl }}{% link _docs/features/api-docs-generator.md %}) 
+to see how you can generate the API documentation, and read them.
 
 <a name="quick-overview"></a>
 ## Quick Overview  
 
 OAuth let's you authenticate using different methods, these methods are called `grants`.
-How to decide which grant type you should use! Check [this](https://oauth2.thephpleague.com/authorization-server/which-grant/), and keep reading this documentation.
+How to decide which grant type you should use! Check [this](https://oauth2.thephpleague.com/authorization-server/which-grant/), 
+and keep reading this documentation.
 
 **Definitions:**
 - The Client credentials: are the `client_id` & `client_secret`.
-- The Proxy: is just an endpoint, that you should call instead of calling the Auth server endpoints directly, the proxy endpoint will append the client credentials to your request and calls the Auth server for you, then return its response back. Each first-client app should have its own proxy endpoints (at least one of Login and one of Token Refresh). By default Apiato provide an `Admin Web Client` endpoints.
+- The Proxy: is just an endpoint, that you should call instead of calling the Auth server endpoints directly, the proxy 
+endpoint will append the client credentials to your request and calls the Auth server for you, then return its response back. Each first-client app should have its own proxy endpoints (at least one of Login and one of Token Refresh). By default Apiato provide an `Admin Web Client` endpoints.
 
 <br>
 
-> You can Login to the first party app with proxy or without proxy, while for the third party you only need to login without proxy. (same apply to refreshing token).
+> You can Login to the first party app with proxy or without proxy, while for the third party you only need to login 
+> without proxy. (same apply to refreshing token).
 >
 > For first party apps:
 > - With Proxy << best and easiest way, (requires manually generating clients creating proxy endpoints for each client)
@@ -81,7 +86,6 @@ How to decide which grant type you should use! Check [this](https://oauth2.theph
 >
 > For third party apps:
 > - Without Proxy << you don't need a proxy for the third party clients as they usually integrate with your API from the backend side which protects the client credentials.
-
 
 <br>
 
@@ -92,28 +96,33 @@ First-party clients (Your Frontend Mobile, Web,... Apps) usually consumes your p
 
 For first-party clients you need to use the **Resource owner credentials grant** (A.K.A Password Grant Tokens).
 
-When this grant type is used, your server needs to authenticate the Client App first (ensuring the request is coming from your trusted frontend App) and then needs to check if the user credentials are correct (ensuring the user is registered and has the right access), before issuing an access token.
-
+When this grant type is used, your server needs to authenticate the Client App first (ensuring the request is coming 
+from your trusted frontend App) and then needs to check if the user credentials are correct (ensuring the user is 
+registered and has the right access), before issuing an access token.
 
 **Note:**
 
-- On register: the API returns user data. You will need to log that user in (using the same credentials he passed) to get his Access Token and make other API calls.
-- On login: the API returns the user Access Token with Refresh Token. You will need to request the User data by making another call to the user endpoint, using his Access Token.
-
+- On register: the API returns user data. You will need to log that user in (using the same credentials he passed) to 
+get his Access Token and make other API calls.
+- On login: the API returns the user Access Token with Refresh Token. You will need to request the User data by making 
+another call to the user endpoint, using his Access Token.
 
 **How it works:**
 
-1) Create a password type Client in your database to represent one of your Apps (ex: Mobile App). Use `php artisan passport:client --password` to generate the client.
+1) Create a password type Client in your database to represent one of your Apps (ex: Mobile App). Use 
+`php artisan passport:client --password` to generate the client.
 
 2) After registration the user can enter his (username + password) in your App login screen.
 
-3) Your App should send a **Post** request to `http://api.apiato.dev/v1/oauth/token` containing the user credentials (`username` and `password`) and the client credentials (`client_id` and `client_secret`) in addition to the `scope` and `grant_type=password`:
+3) Your App should send a **Post** request to `http://api.apiato.develop/v1/oauth/token` containing the user credentials 
+(`username` and `password`) and the client credentials (`client_id` and `client_secret`) in addition to the `scope` 
+and `grant_type=password`:
 
 **Request:**
 
 ```shell
 curl --request POST \
-  --url http://api.apiato.dev/v1/oauth/token \
+  --url http://api.apiato.develop/v1/oauth/token \
   --header 'accept: application/json' \
   --header 'content-type: application/x-www-form-urlencoded' \
   --data 'username=admin%40admin.com&password=admin&client_id=2&client_secret=SGUVv02b1ppQCgI7ZVeoTZDN6z8SSFLYiMOzzfiE&grant_type=password&scope='
@@ -130,7 +139,8 @@ curl --request POST \
 }
 ```
 
-4) Your Client App should save the Tokens and start requesting secure data, by sending the Access Token in the HTTP Header `Authorization = Bearer {Access-Token}`.
+4) Your Client App should save the Tokens and start requesting secure data, by sending the Access Token in the HTTP 
+Header `Authorization = Bearer {Access-Token}`.
 
 More info at [Laravel Passport Here](https://laravel.com/docs/5.6/passport#password-grant-tokens)
 
@@ -138,21 +148,26 @@ More info at [Laravel Passport Here](https://laravel.com/docs/5.6/passport#passw
 
 > WARNING: the Client ID and Secret should not be stored in JavaScript or browser cache, or made accessible in any way.
 
-So in case of Web Apps (JavaScript) you need to hide your client credentials behind a proxy. And Apiato by default provides you with a Login Proxy to use for all your trusted first party clients. W'll see below how you can use them.
+So in case of Web Apps (JavaScript) you need to hide your client credentials behind a proxy. And Apiato by default 
+provides you with a Login Proxy to use for all your trusted first party clients. W'll see below how you can use them.
 
 <a name="login-with-proxy-for-first-party-clients"></a>
 ### Login with Proxy for first-party clients
 
 Concept: create endpoint for each trusted client, to be used for login.
 
-Apiato by default has one url ready for your Web Admin Dashboard `clients/web/admin/login`. You can add more as you need for each of your trusted first party clients Apps (example: `clients/web/users/login`, `clients/mobile/users/login`).
+Apiato by default has one url ready for your Web Admin Dashboard `clients/web/admin/login`. You can add more as you 
+need for each of your trusted first party clients Apps (example: `clients/web/users/login`, `clients/mobile/users/login`).
 
-Behind the scene, that endpoint is appending the corresponding client ID and Secret to your request and making another call to your Auth server with all the required data. *(this way the client does not need to send the ID and Secret with the request, and he is using his own URL which gives even more control to which client is accessing your Server)*.
-Then it returns the Auth response back to the client with the Tokens in it.
+Behind the scene, that endpoint is appending the corresponding client ID and Secret to your request and making another 
+call to your Auth server with all the required data. *(this way the client does not need to send the ID and Secret with 
+the request, and he is using his own URL which gives even more control to which client is accessing your Server)*. Then 
+it returns the Auth response back to the client with the Tokens in it.
 
 Note: You have to manually extract the Client credentials from the DB and put them in the `.env`, for each client.
 
-When running `passport:install` it automatically creates one client for you with ID 2, so you can use that for your first app. Or you can use `php artisan passport:client --password` to generate them.
+When running `passport:install` it automatically creates one client for you with ID 2, so you can use that for your 
+first app. Or you can use `php artisan passport:client --password` to generate them.
 
 `.env` Example:
 
@@ -164,31 +179,38 @@ CLIENT_WEB_ADMIN_SECRET=VkjYCUk5DUexJTE9yFAakytWCOqbShLgu9Ql67TI
 <a name="login-without-proxy-for-first-party-clients"></a>
 ### Login without Proxy for first-party clients
 
-Login from your App by sending a POST request to `http://api.apiato.dev/v1/oauth/token` with `grant_type=password`, the User credentials (`username` & `password`), Client Credentials (`client_id` & `client_secret`) and finally the `scope` which could be empty.
+Login from your App by sending a POST request to `http://api.apiato.develop/v1/oauth/token` with `grant_type=password`, 
+the User credentials (`username` & `password`), Client Credentials (`client_id` & `client_secret`) and finally the 
+`scope` which could be empty.
 
 
 <a name="third-party-clients"></a>
 ## B: For third-party clients
 
-Third party clients (User's custom external Apps, who wants to integrate with your Software) always consumes your public API (External API) only.
+Third party clients (User's custom external Apps, who wants to integrate with your Software) always consumes your 
+public API (External API) only.
 
-For third-party clients you need to use the **Client credentials grant** (A.K.A Personal Access Tokens). *This grant type is the simplest and is suitable for machine-to-machine authentication.*
+For third-party clients you need to use the **Client credentials grant** (A.K.A Personal Access Tokens). *This grant 
+type is the simplest and is suitable for machine-to-machine authentication.*
 
 With this grant type your server needs to authenticate the Client App only, before issuing an access token.
 
 **How it works**
 
-1) User logs in to your Clients App Interface (an external App made for your users only), go to settings, create Client (of type `personal`) and copy the ID and Secret. *(Note this can be done via an API if you prefer)*
+1) User logs in to your Clients App Interface (an external App made for your users only), go to settings, create Client 
+(of type `personal`) and copy the ID and Secret. *(Note this can be done via an API if you prefer)*
 
 You may generate a personal client for testing purposes using `php artisan passport:client --personal`.
 
-2) User add the Client credentials to his "Server Side software" and send a **Post** request to `http://api.apiato.dev/v1/oauth/token` containing the Client credentials (`client_id` and `client_secret`) in addition to the `scope` and `grant_type=client_credentials`:
+2) User add the Client credentials to his "Server Side software" and send a **Post** request to 
+`http://api.apiato.develop/v1/oauth/token` containing the Client credentials (`client_id` and `client_secret`) in 
+addition to the `scope` and `grant_type=client_credentials`:
 
 Request:
 
 ```shell
 curl --request POST \
-  --url http://api.apiato.dev/v1/oauth/token \
+  --url http://api.apiato.develop/v1/oauth/token \
   --header 'accept: application/json' \
   --header 'content-type: application/x-www-form-urlencoded' \
   --data 'client_id=1&client_secret=y1RbtnOvh9rpA91zPI2tiVKmFlepNy9dhHkzUKle&grant_type=client_credentials&scope='
@@ -205,22 +227,27 @@ Response:
 }
 ```
 
-3) The Client will be granted an Access Token to be saved. Then the Client can start requesting secure data, by sending the Access Token in the HTTP Header `Authorization = Bearer {Access-Token}`.
+3) The Client will be granted an Access Token to be saved. Then the Client can start requesting secure data, by sending 
+the Access Token in the HTTP Header `Authorization = Bearer {Access-Token}`.
 
-Note: When a new user is registered, will be issued a personal Access Token automatically. Check the User "Registration page".
+Note: When a new user is registered, will be issued a personal Access Token automatically. Check the User 
+"Registration page".
 
 More info at [Laravel Passport Here](https://laravel.com/docs/5.6/passport#personal-access-tokens)
 
 <a name="login-without-proxy-for-third-party-clients"></a>
 ### Login without Proxy for third-party clients
 
-We usually do not need a proxy for third-party clients as they are most likely making calls form their servers, thus the Client ID and Secret should be secure and not exposed to the users.
+We usually do not need a proxy for third-party clients as they are most likely making calls form their servers, thus 
+the Client ID and Secret should be secure and not exposed to the users.
 
-Login by sending a POST request to `http://api.apiato.dev/v1/oauth/token` with `grant_type=client_credentials`, Client Credentials (`client_id` & `client_secret`) and finally the `scope` which could be empty.
+Login by sending a POST request to `http://api.apiato.develop/v1/oauth/token` with `grant_type=client_credentials`, 
+Client Credentials (`client_id` & `client_secret`) and finally the `scope` which could be empty.
 
 
 Once issued, you can use that Access Token to make requests to protected resources (Endpoints).
-The Access Token should be sent in the `Authorization` header of type `Bearer` Example: `Authorization = Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUz...`
+The Access Token should be sent in the `Authorization` header of type `Bearer` 
+(Example: `Authorization = Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUz...`)
 
 **Keep in mind there's no session state when using Tokens for Authentication**
 
@@ -229,22 +256,23 @@ The Access Token should be sent in the `Authorization` header of type `Bearer` E
 
 > This feature is supported with Apiato 7.4.
 
-By default, Apiato allows `User`s to log in with their `email` address. However, you may want to also allow `username` and 
-`phone` to login your users. 
+By default, Apiato allows `User`s to log in with their `email` address. However, you may want to also allow `username` 
+and `phone` to login your users. 
   
 Here is, how to configure and use this feature.
 
 - You may need to adapt your database accordingly (e.g., add the respective field to the `users` table).
 - You may need to adapt the `Task` that `create` a `User` object (e.g., the `CreateUserByCredentialsTask`) accordingly 
   to support the new fields. This may also affect your `Register` logic.
-- Check the `App\Containers\Authentication\Configs\authentication-container` Configuration file and check the `login` params 
-  in order to configure this feature.
-- Adapt the `ProxyApiLoginTransporter` accordingly to support your new Login Fields. These fields need to be added to `properties`
+- Check the `App\Containers\Authentication\Configs\authentication-container` Configuration file and check the `login` 
+params in order to configure this feature.
+- Adapt the `ProxyApiLoginTransporter` accordingly to support your new Login Fields. These fields need to be added 
+to `properties`
 
 <a name="logout"></a>
 ## Logout
 
-Logout by sending a `DELETE` request to `http://api.apiato.dev/v1/logout/` containing the Token in the Header.
+Logout by sending a `DELETE` request to `http://api.apiato.develop/v1/logout/` containing the Token in the Header.
 
 ```json
 {
@@ -359,15 +387,22 @@ This will be looking for (login.html or login.php or login.blade.php).
 <a name="refresh_token"></a>
 ## Refresh Token
 
-In case your server is issuing a short-lived access tokens, the users will need to refresh their access tokens via the refresh token that was provided to them when the access token was issued.
+In case your server is issuing a short-lived access tokens, the users will need to refresh their access tokens via the 
+refresh token that was provided to them when the access token was issued.
 
 
 <a name="refresh-token-via-proxy-for-first-party-clients"></a>
 
 ### Refresh Token with proxy for first-party clients
-By default Apiato provide this ready endpoint `http://api.poms.dev/v1/clients/web/admin/refresh` for the Web Admin Dashboard Client  to be used when you need to refresh token for that client. You can of course create as many other endpoints as you want for each client. See the code of (`app/Containers/Authentication/UI/API/Routes/ProxyRefreshForAdminWebClient.v1.public.php`) and create similar one for each client. The most important change will be the             `env('CLIENT_WEB_ADMIN_ID')` and `env('CLIENT_WEB_ADMIN_SECRET'),` passed to the `ProxyApiRefreshAction`.
+By default Apiato provide this ready endpoint `http://api.apiato.develop/v1/clients/web/admin/refresh` for the Web 
+Admin Dashboard Client  to be used when you need to refresh token for that client. You can of course create as many 
+other endpoints as you want for each client. See the code of (`app/Containers/Authentication/UI/API/Routes/ProxyRefreshForAdminWebClient.v1.public.php`) 
+and create similar one for each client. The most important change will be the `env('CLIENT_WEB_ADMIN_ID')` and 
+`env('CLIENT_WEB_ADMIN_SECRET'),` passed to the `ProxyApiRefreshAction`.
 
-Those proxy refresh endpoints work in 2 ways. Either by passing the `refresh_token` manually to the endpoint. Or by passing it with the HttpCookie. In both cases the code will work and the server will reply with a response similar to this:
+Those proxy refresh endpoints work in 2 ways. Either by passing the `refresh_token` manually to the endpoint. Or by 
+passing it with the HttpCookie. In both cases the code will work and the server will reply with a response similar to 
+this:
 
 ```json
 {
@@ -384,7 +419,8 @@ Containing new Access Token and new Refresh Token.
 <a name="refresh-token-via-non-proxy"></a>
 ### Refresh Token without proxy for first-party or third-party clients
 
-The request to `http://api.poms.dev/v1/oauth/token` should contain `grant_type=refresh_token`, the `client_id` & `client_secret`, in addition to the `refresh_token` and finally the `scope` which could be empty.
+The request to `http://api.apiato.develop/v1/oauth/token` should contain `grant_type=refresh_token`, the `client_id` & 
+`client_secret`, in addition to the `refresh_token` and finally the `scope` which could be empty.
 
 
 <a name="force-email-confirmation"></a>
@@ -407,10 +443,11 @@ and `/password-reset`  (`app/Containers/User/UI/API/Routes/ResetPassword.v1.publ
 First you need to send a request to the `/password-forgot` endpoint. 
 It will send you an email with a link when you make a request to that link, it will call the `/password-reset` endpoint. 
 
-Note: For security reason, make sure the reset password URL is set in `app/Containers/User/Configs/user-container.php`, and given to the client App, to be sent as parameter when calling the `/password-forgot`. 
+Note: For security reason, make sure the reset password URL is set in `app/Containers/User/Configs/user-container.php`, 
+and given to the client App, to be sent as parameter when calling the `/password-forgot`. 
 
-Note: You must setup the email to get this function to work, 
-however for testing purposes set the `MAIL_DRIVER=log` in your `.env` file in order to the see the email content in the log file `laravel.log`. 
+Note: You must setup the email to get this function to work, however for testing purposes set the `MAIL_DRIVER=log` in 
+your `.env` file in order to the see the email content in the log file `laravel.log`. 
 
 <a name="social-authentication"></a>
 ## Social Authentication

--- a/_docs/features/hash-id.md
+++ b/_docs/features/hash-id.md
@@ -40,9 +40,9 @@ Note: if the feature is set to false `HASH_ID=false` the `getHashedKey()` will r
 
 There are 2 ways an ID's can be passed to your system via the API:
 
-In URL example: `www.apiato.dev/items/abcdef`.
+In URL example: `www.apiato.develop/items/abcdef`.
 
-In parameters example: [GET] or [POST] `www.apiato.dev/items?id=abcdef`.
+In parameters example: [GET] or [POST] `www.apiato.develop/items?id=abcdef`.
 
 in both cases you will need to inform your API about what's coming form the Request class.
 

--- a/_docs/features/pagination.md
+++ b/_docs/features/pagination.md
@@ -36,19 +36,19 @@ The `?limit=` parameter can be applied to define, how many results should be ret
 **Usage:**
 
 ```
-api.domain.dev/endpoint?limit=100
+api.domain.develop/endpoint?limit=100
 ```
 
 This would return 100 resources within one page of the result. Of course, the `limit` and `page` query parameter can be
 combined in order to get the next 100 resources:
 
 ```
-api.domain.dev/endpoint?limit=100&page=2
+api.domain.develop/endpoint?limit=100&page=2
 ```
 
 In order to allow clients to request all data that matches their criteria (e.g., search-criteria) and disable pagination,
 you can manually override the `$allowDisablePagination` property in your specific `Repository` class. A requester can then
-get all data (with no pagination applied) by requesting `api.domain.dev/endpoint?limit=0`. This will return all matching
+get all data (with no pagination applied) by requesting `api.domain.develop/endpoint?limit=0`. This will return all matching
 entities.
 
 

--- a/_docs/features/profiler.md
+++ b/_docs/features/profiler.md
@@ -71,7 +71,7 @@ However, Apiato uses a middleware `app/Ship/Middlewares/Http/ProfilerMiddleware.
         "route": {
             "uri": "GET /",
             "middleware": "api, throttle:30,1",
-            "domain": "http://api.apiato.dev",
+            "domain": "http://api.apiato.develop",
             "as": "apis_root_page",
             "controller": "App\\Containers\\Welcome\\UI\\API\\Controllers\\Controller@apiRoot",
             "namespace": "App\\Containers\\Welcome\\UI\\API\\Controllers",
@@ -108,7 +108,7 @@ However, Apiato uses a middleware `app/Ship/Middlewares/Http/ProfilerMiddleware.
                     "time": 1506105927.694811
                 },
                 {
-                    "message": "[2017-09-18 17:38:15] testing.INFO: New User registration. ID = 970ylqvaogmxnbdr | Email = apiato@mail.dev.      Thank you for signing up.\n</div>\n</body>\n</html>\n  \n",
+                    "message": "[2017-09-18 17:38:15] testing.INFO: New User registration. ID = 970ylqvaogmxnbdr | Email = apiato@mail.develop.      Thank you for signing up.\n</div>\n</body>\n</html>\n  \n",
                     "message_html": null,
                     "is_string": false,
                     "label": "info",

--- a/_docs/features/query-parameters.md
+++ b/_docs/features/query-parameters.md
@@ -91,21 +91,21 @@ Notice should replace the space with `%20`.
 #### Search any field for multiple keywords
 
 ```
-api.domain.dev/endpoint?search=first keyword;second keyword
+api.domain.develop/endpoint?search=first keyword;second keyword
 ```
 
 <a name="search-in-specific-field"></a>
 
 #### Search in specific field
 ```
-api.domain.dev/endpoint?search=field:keyword here
+api.domain.develop/endpoint?search=field:keyword here
 ```
 
 <a name="search-any-field-for-multiple-keywords"></a>
 
 #### Search in specific fields for multiple keywords
 ```
-api.domain.dev/endpoint?search=field1:first field keyword;field2:second field keyword
+api.domain.develop/endpoint?search=field1:first field keyword;field2:second field keyword
 ```
 
 <a name="define-query-condition"></a>
@@ -113,7 +113,7 @@ api.domain.dev/endpoint?search=field1:first field keyword;field2:second field ke
 #### Define query condition
 
 ```
-api.domain.dev/endpoint?search=field:keyword&searchFields=name:like
+api.domain.develop/endpoint?search=field:keyword&searchFields=name:like
 ```
 
 Checkout the Search Page for full implementation example.
@@ -159,7 +159,7 @@ data you want back in the response.
 Return only ID and Name from that Model, (everything else will be returned as `null`).
 
 ```
-api.domain.dev/endpoint?filter=id;status
+api.domain.develop/endpoint?filter=id;status
 ```
 
 Example Response, including only id and status:
@@ -213,7 +213,7 @@ The `?page=` parameter can be applied to any **`GET`** HTTP request responsible 
 **Usage:**
 
 ```
-api.domain.dev/endpoint?page=200
+api.domain.develop/endpoint?page=200
 ```
 
 *The pagination object is always returned in the **meta** when pagination is available on the endpoint.*
@@ -228,7 +228,7 @@ api.domain.dev/endpoint?page=200
       "current_page": 22,
       "total_pages": 1111,
       "links": {
-        "previous": "http://api.domain.dev/endpoint?page=21"
+        "previous": "http://api.domain.develop/endpoint?page=21"
       }
     }
   }
@@ -245,19 +245,19 @@ The `?limit=` parameter can be applied to define, how many results should be ret
 **Usage:**
 
 ```
-api.domain.dev/endpoint?limit=100
+api.domain.develop/endpoint?limit=100
 ```
 
 This would return 100 resources within one page of the result. Of course, the `limit` and `page` query parameter can be
 combined in order to get the next 100 resources:
 
 ```
-api.domain.dev/endpoint?limit=100&page=2
+api.domain.develop/endpoint?limit=100&page=2
 ```
 
 In order to allow clients to request all data that matches their criteria (e.g., search-criteria) and disable pagination,
 you can manually override the `$allowDisablePagination` property in your specific `Repository` class. A requester can then
-get all data (with no pagination applied) by requesting `api.domain.dev/endpoint?limit=0`. This will return all matching
+get all data (with no pagination applied) by requesting `api.domain.develop/endpoint?limit=0`. This will return all matching
 entities.
 
 <a name="relationships-include"></a>
@@ -298,7 +298,7 @@ Of course, the `address` include is defined in the respective `DriverTransformer
 **Usage:**
 
 ```
-api.domain.dev/endpoint?include=relationship
+api.domain.develop/endpoint?include=relationship
 ```
 
 **Where to define the includes:**

--- a/_docs/features/social-authentication.md
+++ b/_docs/features/social-authentication.md
@@ -46,7 +46,7 @@ For Social Authentication Apiato uses [Socialite]( https://github.com/laravel/so
 - For Twitter: [https://apps.twitter.com/app](https://apps.twitter.com/app)
 - For Google: [https://console.developers.google.com/apis/credentials](https://console.developers.google.com/apis/credentials)
 
-For the callback URL you can use this Apiato web endpoint `http://apiato.dev/auth/{provider}/callback` *(replace the provider with any of the supported providers `facebook`, `twitter`,..)*.
+For the callback URL you can use this Apiato web endpoint `http://apiato.develop/auth/{provider}/callback` *(replace the provider with any of the supported providers `facebook`, `twitter`,..)*.
 
 2) Set the Tokens and Secrets in the `.env` file
 
@@ -72,7 +72,7 @@ For the callback URL you can use this Apiato web endpoint `http://apiato.dev/aut
 
 3) Make a request from your client to get the `oauth` info. **Each Social provider returns different response and keys**
 
-For testing purposes Apiato provides a web endpoint (`http://apiato.dev/auth/{provider}` ) to act as a client.
+For testing purposes Apiato provides a web endpoint (`http://apiato.develop/auth/{provider}` ) to act as a client.
 
 Use that endpoint from your browser *(replace the provider with any of the supported providers `facebook`, `twitter`,..)* to get the `oauth` info. 
 
@@ -100,7 +100,7 @@ Example Getting Twitter User: **Twitter requires the `oauth_token` and `oauth_se
 
 ```text
 POST /v1/auth/twitter HTTP/1.1
-Host: api.apiato.dev
+Host: api.apiato.develop
 Content-Type: application/x-www-form-urlencoded
 Accept: application/json
 

--- a/_docs/features/user-registration.md
+++ b/_docs/features/user-registration.md
@@ -12,7 +12,7 @@ order: 5
 
 ### Register users by credentials (email and passwords)
 
-Call the `http://api.apiato.dev/v1/register` endpoint (you can find it's documentation after generating the API Docs.
+Call the `http://api.apiato.develop/v1/register` endpoint (you can find it's documentation after generating the API Docs.
 
 Check out the `registerUser` endpoint in the API Routes files.
 
@@ -23,7 +23,7 @@ This will registered new Users and generates Personal Access Tokens and respond 
 
 ```http
 curl --request POST \
-  --url http://api.apiato.dev/v1/register \
+  --url http://api.apiato.develop/v1/register \
   --header 'accept: application/json' \
   --header 'content-type: application/x-www-form-urlencoded' \
   --data 'email=apiato%40mail.com1&password=password&name=Mahmoud%20Zalt'

--- a/_docs/features/versioning.md
+++ b/_docs/features/versioning.md
@@ -30,9 +30,9 @@ Automatically the endpoint inside that route file will be accessible by adding t
 
 Example: 
 
-- `http://api.apiato.dev/v1/register`
-- `http://api.apiato.dev/v1/orders`
-- `http://api.apiato.dev/v2/stores/123`
+- `http://api.apiato.develop/v1/register`
+- `http://api.apiato.develop/v1/orders`
+- `http://api.apiato.develop/v2/stores/123`
 
 
 

--- a/_docs/getting-started/architecture.md
+++ b/_docs/getting-started/architecture.md
@@ -31,11 +31,6 @@ order: 6
       - [More Classes](#more-classes)
     + [How to use Apiato features](#Apiato-features)
 
-
-
-
-
-
 <a name="intro"></a>
 ### Introduction 
 
@@ -51,9 +46,6 @@ However, it also support building API's using the popular MVC architecture (with
 
 Below you will see how you can both any of the architectures to build your project.
 
-
-
-
 ## Porto
 
 <a name="porto-intro"></a>
@@ -61,31 +53,30 @@ Below you will see how you can both any of the architectures to build your proje
 
 Porto is an architecture that consists of 2 layers the **Containers** layer and the **Ship** layer.
 
-The **Container** layer holds your application business logic code. 
-Same like Modular, DDD and plugins architectures; Apiato allows separating the business logic into multiple folders called **Containers**.
-While the **Ship** layer holds the infrastructure code (your shared code between all **Containers**). You will rarely touch it anyway.
+The **Container** layer holds your application business logic code. Same like Modular, DDD and plugins architectures; 
+Apiato allows separating the business logic into multiple folders called **Containers**. While the **Ship** layer holds 
+the infrastructure code (your shared code between all **Containers**). You will rarely touch it anyway.
 
+The Apiato features themselves are developed using the Porto Software Architectural Pattern. (Means the features 
+provided in Apiato live in Containers).
 
-The Apiato features themselves are developed using the Porto Software Architectural Pattern. (Means the features provided in Apiato live in Containers).
-
-Spending 15 minutes, reading the [Porto Document](https://github.com/Mahmoudz/Porto) before getting started, is a great investment of time.
-
+Spending 15 minutes, reading the [Porto Document](https://github.com/Mahmoudz/Porto) before getting started, is a great 
+investment of time.
 
 <a name="container-layer"></a>
 ### The Containers Layer
 
 Read about the Containers layer [here](https://github.com/Mahmoudz/Porto#Containers-Layer)
 
-
 <a name="rm-container"></a>
 #### Remove a Container (default Containers)
 
 Apiato comes with some default containers. All the containers are optional, and some of them contain essential features.
 
-Let's say you don't want to use the built in documentation generator feature of Apiato. To get rid of that feature you can simply delete the `documentation` container. 
+Let's say you don't want to use the built in documentation generator feature of Apiato. To get rid of that feature you 
+can simply delete the `documentation` container. 
 
 To remove a Container, simply delete the folder then run `composer update` to remove its dependencies.
-
 
 <a name="new-Containter"></a>
 #### Create new Container
@@ -105,45 +96,41 @@ Refer to the [code generator](http://apiato.io/features/code-generator/) page fo
 
 *(The Ship engine will auto load and register everything automatically for you)*.
 
-For the auto-loading to work flawlessly you MUST adhere to the component's naming conventions and directories. So you need to refer to the `documentation page` of the component when creating it.
-
+For the auto-loading to work flawlessly you MUST adhere to the component's naming conventions and directories. So you 
+need to refer to the `documentation page` of the component when creating it.
 
 <a name="Containter-Conventions"></a>
 #### Container Conventions
 
 - Containers names SHOULD start with Capital. Use CamelCase to rename Containers.
-- Namespace should be the same as the container name, (if container name is "Printer" the namespace should be "App\Containers\Printer").
-- Container MAY be named to anything however. A good practice is to name it to its most important Model name. *Example: if the User Story is (User can create a Stores and Stores can have Items) then we you could have 3 Containers (User, Store and Item).*
-
+- Namespace should be the same as the container name, (if container name is "Printer" the namespace should be 
+`App\Containers\Printer`).
+- Container MAY be named to anything however. A good practice is to name it to its most important Model name. 
+*Example: If the User Story is (User can create a Stores and Stores can have Items) then we you could have 3 
+Containers (User, Store and Item).*
 
 <a name="ship-layer"></a>
 ### The Ship Layer
 
 Read about the Ship layer **[here](https://github.com/Mahmoudz/Porto#Port-Layer)**
 
-
-
-
-
-
-
-
 ## MVC 
 
 <a name="mvc-intro"></a>
 ### MVC Introduction
 
-Due to the popularity of MVC, and the fact that many developers don't have enough time to learn about new architectures. Apiato, supports a the MVC architecture. That is 97% compatible with the laravel MVC.
+Due to the popularity of MVC, and the fact that many developers don't have enough time to learn about new architectures. 
+Apiato, supports a the MVC architecture. That is 97% compatible with the laravel MVC.
 
-Below you will learn how you can build your API on top of Apiato, using your previous knowledge of the Laravel MVC framework.
-
+Below you will learn how you can build your API on top of Apiato, using your previous knowledge of the Laravel MVC 
+framework.
 
 <a name="Difference-mvc"></a>
 #### Difference between Standard MVC and Apiato's MVC
 
-The Porto architecture, does not replace the MVC architecture, instead it extends it for good. 
-So Models, Views, Routes and Controllers all still exist, but in different places with a strict set of responsibilities for each component "Class type".
-
+The Porto architecture, does not replace the MVC architecture, instead it extends it for good. So Models, Views, Routes 
+and Controllers all still exist, but in different places with a strict set of responsibilities for each component 
+`class type`.
 
 <a name="Setup-mvc"></a>
 #### Setup my Apiato MVC App
@@ -153,14 +140,16 @@ So Models, Views, Routes and Controllers all still exist, but in different place
 ##### 2) Create the Application
 
 If you open `app/Containers/` you will see a list of Proto's Containers, each container provide some features for you. 
-However, you don't need to modify them, whether you are using the Porto or MVC architecture. 
-So forget about all these folders for now.
+However, you don't need to modify them, whether you are using the Porto or MVC architecture. So forget about all these 
+folders for now.
 
-All we need is to create a new folder called `Application` (your MVC application, it's an alternative to the `app` folder on the root of the Laravel project). This folder will hold all your Models, Views, Routes, Controllers etc files.
+All we need is to create a new folder called `Application` (your MVC application, it's an alternative to the `app` 
+folder on the root of the Laravel project). This folder will hold all your Models, Views, Routes, Controllers etc files.
 
 ##### 3) Create route file
 
-In Laravel 5.6, the routes files live in the `routes/` folder on the root of the project. But In Apiato MVC, the routes files should live in:
+In Laravel 5.6, the routes files live in the `routes/` folder on the root of the project. But In Apiato MVC, the routes 
+files should live in:
 
 - `app/Containers/Application/UI/API/Routes/` (for API Routes)
 - `app/Containers/Application/UI/WEB/Routes/` (for WEB Routes)
@@ -190,52 +179,58 @@ Route::get('/', function () {
 
 ##### 4) Create Controller
 
-In Laravel 5.6, the Controllers classes live in the `app/Http/Controllers/` folder. But In Apiato MVC, the Controllers classes should live in:
+In Laravel 5.6, the Controllers classes live in the `app/Http/Controllers/` folder. But In Apiato MVC, the `Controller` 
+classes should live in:
 
-- `app/Containers/Application/UI/API/Controllers/Controller.php` (To handle API Routes) MUST extend from `App\Ship\Parents\Controllers\ApiController `
-- `app/Containers/Application/UI/WEB/Controllers/Controller.php` (To handle WEB Routes) MUST extend from `App\Ship\Parents\Controllers\ WebController `
+- `app/Containers/Application/UI/API/Controllers/Controller.php` (To handle API Routes) MUST extend from `App\Ship\Parents\Controllers\ApiController`
+- `app/Containers/Application/UI/WEB/Controllers/Controller.php` (To handle WEB Routes) MUST extend from `App\Ship\Parents\Controllers\WebController`
 
 ##### 5) Create Models
 
-In Laravel 5.6, the Models classes live in the root of the `app/` folder. But In Apiato MVC, the Models classes should live in `app/Containers/Application/Models/`.
+In Laravel 5.6, the Models classes live in the root of the `app/` folder. But In Apiato MVC, the Models classes should 
+live in `app/Containers/Application/Models`.
 
 All model must `extend` from `App\Ship\Parents\Models\Model`.
 
-> Note the `User` Model should remain in the User Container (`app/Containers/User/Models/User.php`), to keep all the features working without any modifications.
+> Note the `User` Model should remain in the User Container (`app/Containers/User/Models/User.php`), to keep all the 
+features working without any modifications.
 
 ##### 6) Create Views
 
-In Laravel 5.6, the Views files live in the `resources/views/` folder. In Apiato MVC, the Views files can live in that same directory or/and in this container folder `app/Containers/Application/UI/WEB/Views/`.
-
+In Laravel 5.6, the Views files live in the `resources/views/` folder. In Apiato MVC, the Views files can live in that 
+same directory or/and in this container folder `app/Containers/Application/UI/WEB/Views/`.
 
 ##### 7) Create Transformers
 
-In Laravel 5.6, the Transformers classes live in the `app/Transformers/` folder. But In Apiato MVC, the Controllers classes should live in `app/Containers/Application/UI/API/Transformers/`.
-
+In Laravel 5.6, the Transformers classes live in the `app/Transformers/` folder. But In Apiato MVC, the Controllers 
+classes should live in `app/Containers/Application/UI/API/Transformers/`.
 
 Transformers must extend from `App\Ship\Parents\Transformers\Transformer`.
 
 ##### 8) Create Service Providers
 
-In Laravel 5.6, the Service Providers classes live in the `app/Providers/` folder. But In Apiato MVC, the Controllers classes can live in `app/Containers/Application/Providers/`, but also can live anywhere else.
+In Laravel 5.6, the Service Providers classes live in the `app/Providers/` folder. But In Apiato MVC, the Controllers 
+classes can live in `app/Containers/Application/Providers/`, but also can live anywhere else.
 
-If you want the Service Providers to be automatically loaded (without having to register it in the `config/app.php` file), rename your file to  `MainServiceProvider.php` (full path `app/Containers/Application/Providers/MainServiceProvider.php`). Otherwise you can create Service Providers anywhere and register them manually in Laravel.
-
+If you want the Service Providers to be automatically loaded (without having to register it in the `config/app.php` 
+file), rename your file to  `MainServiceProvider.php` (full path `app/Containers/Application/Providers/MainServiceProvider.php`). 
+Otherwise you can create Service Providers anywhere and register them manually in Laravel.
 
 ##### 9) Create Migrations
 
-In Laravel 5.6, the Migrations classes live in the `database/migrations/` folder on the root of the project. In Apiato MVC, the Migrations classes can live in that same directory or/and in this container folder `app/Containers/Application/Data/Migrations/`.
-
+In Laravel 5.6, the Migrations classes live in the `database/migrations/` folder on the root of the project. In Apiato 
+MVC, the Migrations classes can live in that same directory or/and in this container folder 
+`app/Containers/Application/Data/Migrations/`.
 
 ##### 10) Create Seeds
 
-In Laravel 5.6, the Seeds files live in the `database/migrations/` folder on the root of the project. In Apiato MVC, the Seeds files can live in that same directory or/and in this container folder `app/Containers/Application/Data/Seeders/`.
-
+In Laravel 5.6, the Seeds files live in the `database/migrations/` folder on the root of the project. In Apiato MVC, the 
+Seeds files can live in that same directory or/and in this container folder `app/Containers/Application/Data/Seeders/`.
 
 ##### More Classes
 
-All other classes types work the same way, you can refer to the documentation for where to place them and what they should extend. For more details you can always get in touch with us on **Slack**.
-
+All other classes types work the same way, you can refer to the documentation for where to place them and what they 
+should extend. For more details you can always get in touch with us on **Slack**.
 
 <a name="Apiato-features"></a>
 #### How to use Apiato features
@@ -255,4 +250,3 @@ You can use Actions/Tasks classes anyway you want:
 - Without Apiato involvement using plain Laravel IoC `$user = \App::make(GetDriversAction::class)->run($request->id);`
 
 Be creative, at the end of the day it's a class with a function.
-

--- a/_docs/getting-started/conventions-principles.md
+++ b/_docs/getting-started/conventions-principles.md
@@ -10,7 +10,6 @@ order: 7
 * [Good URL examples](#Good-examples) 
 * [General principles for HTTP methods](#General-principles) 
 
-
 <a name="HTTP-Methods"></a>
 ### HTTP Methods usage in RESTful API's
 - GET (SELECT): retrieve a specific resource from the server, or a listing of resources.
@@ -18,8 +17,6 @@ order: 7
 - PUT (UPDATE): update a resource on the server, providing the entire resource.
 - PATCH (UPDATE): update a resource on the server, providing only changed attributes.
 - DELETE (DELETE): remove a resource from the server.
-
-
 
 <a name="Naming-Conventions"></a>
 ### Naming Conventions for Routes & Actions
@@ -30,9 +27,6 @@ order: 7
 - **UpdateResource**: to update/edit existing resource. 
 - **DeleteResource**: to delete a resource.
 
-
-
-
 <a name="General-guidelines"></a>
 ### General guidelines and principles for RESTful URLs
 
@@ -41,7 +35,7 @@ order: 7
 - Use plural nouns only for consistency (no singular nouns).
 - Use HTTP verbs (GET, POST, PUT, DELETE) to operate on the collections and elements.
 - You should not need to go deeper than resource/identifier/resource.
-- Put the version number at the base of your URL, for example `http://apiato.dev/v1/path/to/resource`.
+- Put the version number at the base of your URL, for example `http://apiato.develop/v1/path/to/resource`.
 - If an input data changes the logic of the endpoint, it should be passed in the URL. If not can go in the header "like Auth Token".
 - Don't use query parameters to alter state.
 - Don't use mixed-case paths if you can help it; lowercase is best.
@@ -49,36 +43,32 @@ order: 7
 - Limit your URI space as much as possible. And keep path segments short.
 - Don't put metadata in the body of a response that should be in a header
 
-
-
 <a name="Good-examples"></a>
 ### Good URL examples
 
 - Find a single Car by its unique identifier (ID):
-	- `GET http://www.api.apiato.dev/v1/cars/123`
+	- `GET http://www.api.apiato.develop/v1/cars/123`
 - Get all Cars:
-	- `GET http://www.api.apiato.dev/v1/cars`
+	- `GET http://www.api.apiato.develop/v1/cars`
 - Find/Search cars by one or more fields:
-	- `GET http://www.api.apiato.dev/v1/cars?search=maker:mercedes`
-	- `GET http://www.api.apiato.dev/v1/cars?search=maker:mercedes;color:white`
+	- `GET http://www.api.apiato.develop/v1/cars?search=maker:mercedes`
+	- `GET http://www.api.apiato.develop/v1/cars?search=maker:mercedes;color:white`
 - Order and Sort query result:
-	- `GET http://www.api.apiato.dev/v1/cars?orderBy=created_at&sortedBy=desc`
-	- `GET http://www.api.apiato.dev/v1/cars?search=maker:mercedes&orderBy=created_at&sortedBy=desc`
+	- `GET http://www.api.apiato.develop/v1/cars?orderBy=created_at&sortedBy=desc`
+	- `GET http://www.api.apiato.develop/v1/cars?search=maker:mercedes&orderBy=created_at&sortedBy=desc`
 - Specify optional fields:
-	- `GET http://www.api.apiato.dev/v1/cars?filter=id;name;status`
-	- `GET http://www.api.apiato.dev/v1/cars/123?filter=id;name;status`
+	- `GET http://www.api.apiato.develop/v1/cars?filter=id;name;status`
+	- `GET http://www.api.apiato.develop/v1/cars/123?filter=id;name;status`
 - Get all Drivers belonging to a Car:
-	- `GET http://www.api.apiato.dev/v1/cars/123/drivers`
-	- `GET http://www.api.apiato.dev/v1/cars/123/drivers/123/addresses`
+	- `GET http://www.api.apiato.develop/v1/cars/123/drivers`
+	- `GET http://www.api.apiato.develop/v1/cars/123/drivers/123/addresses`
 - Include Drivers objects relationship with the car response:
-	- `GET http://www.api.apiato.dev/v1/cars/123?include=drivers`
-	- `GET http://www.api.apiato.dev/v1/cars/123?include=drivers,owner`
+	- `GET http://www.api.apiato.develop/v1/cars/123?include=drivers`
+	- `GET http://www.api.apiato.develop/v1/cars/123?include=drivers,owner`
 - Add new Car:
-	- `POST http://www.api.apiato.dev/v1/cars`
+	- `POST http://www.api.apiato.develop/v1/cars`
 - Add new Driver to a Car:
-	- `POST http://www.api.apiato.dev/v1/cars/123/drivers`
-
-
+	- `POST http://www.api.apiato.develop/v1/cars/123/drivers`
 
 <a name="General-principles"></a>
 ### General principles for HTTP methods
@@ -92,7 +82,3 @@ order: 7
 - Use POST whenever you have to do something that feels RPC-like.
 - Use PUT for classes of resources that are larger or hierarchical.
 - Use DELETE in preference to POST to remove resources.
-
-
-
-

--- a/_docs/getting-started/installation.md
+++ b/_docs/getting-started/installation.md
@@ -19,25 +19,18 @@ order: 2
 * [C) Play](#Play)
 
 
- 
- 
-
-
 <a name="App"></a>
 ## A) Apiato Application Installation
 
 **Apiato** can be installed automatically with Composer (recommended) or manually (with Git or direct download):
 
-
 <a name="Code-Setup"></a>
 ### 1) Code Setup
-
 
 <a name="App-Composer"></a>
 #### 1.A) Automatically via Composer
 
 1) Clone the repo, install dependencies and setup the project:
-
 
 Option 1: Latest [stable](https://github.com/apiato/apiato/releases/latest) release (**7.4**):
 
@@ -52,7 +45,8 @@ composer create-project apiato/apiato my-api ~7.2
 ```
 
 Option 3: On going [development](https://github.com/apiato/apiato/commits/master) branch "dev master" *(unstable)*:
-*This gives you features from the upcoming releases. But you need to keep syncing your project with the upstream master branch and running composer update when changes occurs.* 
+*This gives you features from the upcoming releases. But you need to keep syncing your project with the upstream master 
+branch and running composer update when changes occurs.* 
 
 ```shell
 composer create-project apiato/apiato my-api dev-master
@@ -66,7 +60,6 @@ composer create-project apiato/apiato my-api dev-master
 #### 1.B) Manually
 
 You can download the Code directly from the repository as `.ZIP` file or clone the repository using `Git` (recommended):
-
 
 1) Clone the repository using `Git`:
 
@@ -96,15 +89,12 @@ php artisan key:generate
 
 5) delete the `.git` folder from the root directory and initialize your own with `git init`.
 
-
-
-
 <a name="Setup-Database"></a>
 ### 2) Database Setup
 
 1) Migrate the Database:
 
-b. Run the migration artisan command:
+Run the migration artisan command:
 
 ```shell
 php artisan migrate
@@ -116,23 +106,27 @@ php artisan migrate
 php artisan db:seed
 ```
 
-3) Optional. By default Apiato seeds a "Super User", given the default `admin` role (the role has no Permissions set to it). 
+3) Optional. By default Apiato seeds a "Super User", given the default `admin` role (the role has no Permissions set 
+to it). 
 
-To give the `admin` role, access to all the seeded permissions in the system, run the following command `php artisan apiato:permissions:toRole admin` at any time.
+To give the `admin` role, access to all the seeded permissions in the system, run the following command 
+```
+php artisan apiato:permissions:toRole admin
+```
+at any time.
 
-**NOTE:** if you are using Laradock, you need to run those commands from the `workspace` Container, you can enter that container by running `docker-compose exec workspace bash` from the Laradock folder.
-
+**NOTE:** if you are using Laradock, you need to run those commands from the `workspace` Container, you can enter that 
+container by running `docker-compose exec workspace bash` from the Laradock folder.
 
 <a name="Prepare-OAuth"></a>
 ### 3) OAuth 2.0 Setup 
 
-
-1) Create encryption keys to generate secure access tokens and create "personal access" and "password grant" clients which will be used to generate access tokens:
+1) Create encryption keys to generate secure access tokens and create "personal access" and "password grant" clients 
+which will be used to generate access tokens:
 
 ```shell
 php artisan passport:install
 ```
-
 
 <a name="Documentation"></a>
 ### 4) Documentation Setup
@@ -147,16 +141,17 @@ Install it Globally with `-g` or locally in the project without `-g`
 npm install apidoc -g
 ```
 
-Or install it by just running `npm install` on the root of the project, after checking the `package.json` file on the root. 
-
+Or install it by just running `npm install` on the root of the project, after checking the `package.json` file on the 
+root. 
 
 2) run `php artisan apiato:docs`
 
-Behind the scene `apiato:docs` is executing a command like this `apidoc -c app/Containers/Documentation/ApiDocJs/public -f public.php -i app -o public/api/documentation`.
+Behind the scene `apiato:docs` is executing a command like this
+```
+apidoc -c app/Containers/Documentation/ApiDocJs/public -f public.php -i app -o public/api/documentation
+```
 
 ##### Visit [API Docs Generator]({{ site.baseurl }}{% link _docs/features/api-docs-generator.md %}) for more details.
-
-
 
 <a name="Testing"></a>
 ### 5) Testing Setup
@@ -169,18 +164,21 @@ Behind the scene `apiato:docs` is executing a command like this `apidoc -c app/C
 vendor/bin/phpunit
 ```
 
-
-
-
-
-
-
-
 <a name="Development-Environment"></a>
 ## B) Development Environment Setup
 
-You can run **Apiato** on your favorite environment. Below you'll see how you can run it on top of [Vagrant](https://www.vagrantup.com/) (using [Laravel Homestead](https://laravel.com/docs/master/homestead)) or [Docker](https://www.docker.com/) (using [Laradock](https://github.com/Laradock/laradock)). 
-We'll see how to use both tools and you can pick one, or you can use other options like [Larvel Valet](https://laravel.com/docs/valet), [Laragon](https://laragon.org/) or even run it directly on your machine.
+You can run **Apiato** on your favorite environment. Below you'll see how you can run it on top of 
+[Vagrant](https://www.vagrantup.com/) (using [Laravel Homestead](https://laravel.com/docs/master/homestead)) or 
+[Docker](https://www.docker.com/) (using [Laradock](https://github.com/Laradock/laradock)). 
+
+We'll see how to use both tools and you can pick one, or you can use other options like 
+[Larvel Valet](https://laravel.com/docs/valet), [Laragon](https://laragon.org/) or even run it directly on your machine.
+
+> #### Heads up!
+> 
+> The ICANN has now officially approved `.dev` as a generic top level domain (gTLD). Therefore, it is **not** recommended 
+> to use `.dev` domains any more in your local development setup! The docs here has been changed to use `.develop` 
+> instead of `.dev`, however, you may change to `.localhost` or `.test` or whatever suits your needs.
 
 <a name="Dev-Env-Opt-A"></a>
 ### A.1) Using Docker (with Laradock)
@@ -214,19 +212,19 @@ docker-compose up -d nginx mysql redis beanstalkd
 
 5.1) Open the hosts file on your local machine `/etc/hosts`.
 
-*We'll be using `apiato.dev` as local domain (you can change it if you want).*
+*We'll be using `apiato.develop` as local domain (you can change it if you want).*
 
 5.2) Map the domain and its subdomains to 127.0.0.1:
 
 ```text
-127.0.0.1  apiato.dev
-127.0.0.1  api.apiato.dev
-127.0.0.1  admin.apiato.dev
+127.0.0.1  apiato.develop
+127.0.0.1  api.apiato.develop
+127.0.0.1  admin.apiato.develop
 ```
 
-If you're using NGINX or Apache, make sure the **server_name** (in case of NGINX) or **ServerName** (in case of Apache) in your the server config file, is set to the following `apiato.dev api.apiato.dev admin.apiato.dev`. 
+If you're using NGINX or Apache, make sure the **server_name** (in case of NGINX) or **ServerName** (in case of Apache) 
+in your the server config file, is set to the following `apiato.develop api.apiato.develop admin.apiato.develop`.  
 *(Also don't forget to set your **root** or **DocumentRoot** to the public directory inside apiato `apiato/public`)*.
-
 
 <a name="Dev-Env-Opt-B"></a>
 ### A.2) Using Vagrant (with Laravel Homestead)
@@ -239,35 +237,34 @@ If you're using NGINX or Apache, make sure the **server_name** (in case of NGINX
 homestead edit
 ```
 
-1.2) Map the `api.apiato.dev` domain to the project public directory - Example:
+1.2) Map the `api.apiato.develop` domain to the project public directory - Example:
 
 ```text
 sites:
-	- map: api.apiato.dev
+	- map: api.apiato.develop
   	  to: /{full-path-to}/apiato/public
 ```
 
-1.3) You can also map other domains like `apiato.dev` and `admin.apiato.dev` to other web apps:
+1.3) You can also map other domains like `apiato.develop` and `admin.apiato.develop` to other web apps:
 
 ```text
-	- map: apiato.dev
+	- map: apiato.develop
   	  to: /{full-path-to}/clients/web/user
-	- map: admin.apiato.dev
+	- map: admin.apiato.develop
   	  to: /{full-path-to}/clients/web/admin
 ```
 
-Note: in the example above the `/{full-path-to}/clients/web/***` are separate apps, who live on their own 
-repositories and in different folder then the Apiato one. 
-If your Admins, Users or other type of Apps are within Apiato, then 
-you must point them all to the Apiato project folder `/{full-path-to}/apiato/public`. 
-So in that case you would have something like this:
+Note: in the example above the `/{full-path-to}/clients/web/***` are separate apps, who live on their own repositories 
+and in different folder then the Apiato one. If your Admins, Users or other type of Apps are within Apiato, then you 
+must point them all to the Apiato project folder `/{full-path-to}/apiato/public`. So in that case you would have 
+something like this:
  
 ```text
-    - map: api.apiato.dev
+    - map: api.apiato.develop
       to: /{full-path-to}/apiato/public
-    - map: apiato.dev
+    - map: apiato.develop
       to: /{full-path-to}/apiato/public
-    - map: admin.apiato.dev
+    - map: admin.apiato.develop
       to: /{full-path-to}/apiato/public
 ```
 
@@ -275,19 +272,19 @@ So in that case you would have something like this:
 
 2.1) Open the hosts file on your local machine `/etc/hosts`.
 
-*We'll be using `apiato.dev` as local domain (you can change it if you want).*
+*We'll be using `apiato.develop` as local domain (you can change it if you want).*
 
 2.2) Map the domain and its subdomains to the Vagrant IP Address:
 
 ```text
-192.168.10.10   apiato.dev
-192.168.10.10   api.apiato.dev
-192.168.10.10   admin.apiato.dev
+192.168.10.10   apiato.develop
+192.168.10.10   api.apiato.develop
+192.168.10.10   admin.apiato.develop
 ```
 
-If you're using NGINX or Apache, make sure the **server_name** (in case of NGINX) or **ServerName** (in case of Apache) in your the server config file, is set to the following `apiato.dev api.apiato.dev admin.apiato.dev`. 
+If you're using NGINX or Apache, make sure the **server_name** (in case of NGINX) or **ServerName** (in case of Apache) 
+in your the server config file, is set to the following `apiato.develop api.apiato.develop admin.apiato.develop`. 
 *(Also don't forget to set your **root** or **DocumentRoot** to the public directory inside apiato `apiato/public`)*.
-
 
 2.3) Run the Virtual Machine:
 
@@ -301,8 +298,8 @@ try running this command `homestead halt && homestead up --provision`.*
 <a name="Dev-Env-Opt-C"></a>
 ### A.3) Using something else
 
-If you're not into virtualization solutions, you can setup your environment directly on your machine. 
-Check the [software's requirements list]({{ site.baseurl }}{% link _docs/getting-started/requirements.md %}).
+If you're not into virtualization solutions, you can setup your environment directly on your machine. Check the 
+[software's requirements list]({{ site.baseurl }}{% link _docs/getting-started/requirements.md %}).
 
 <a name="Play"></a>
 ## C) Play
@@ -311,25 +308,26 @@ Now let's see it in action
 
 1.a. Open your web browser and visit: 
 
-- `http://apiato.dev` You should see an HTML page, with `Apiato` in the middle.
-- `http://admin.apiato.dev` You should see an HTML Login page.
+- `http://apiato.develop` You should see an HTML page, with `Apiato` in the middle.
+- `http://admin.apiato.develop` You should see an HTML Login page.
 
 1.b. Open your HTTP client and call: 
 
-- `http://api.apiato.dev/` You should see a JSON response with message: `"Welcome to apiato."`, 
-- `http://api.apiato.dev/v1` You should see a JSON response with message: `"Welcome to apiato (API V1)."`,   
+- `http://api.apiato.develop/` You should see a JSON response with message: `"Welcome to apiato."`, 
+- `http://api.apiato.develop/v1` You should see a JSON response with message: `"Welcome to apiato (API V1)."`,   
 
 2) Make some HTTP calls to the API:
 
-*To make the calls you can use [Postman](https://www.getpostman.com/), [HTTPIE](https://github.com/jkbrzt/httpie) or any other tool you prefer.*
+*To make the calls you can use [Postman](https://www.getpostman.com/), [HTTPIE](https://github.com/jkbrzt/httpie) or 
+any other tool you prefer.*
 
-Let's test the (user registration) endpoint `http://api.apiato.dev/v1/register ` with **cURL**:
+Let's test the (user registration) endpoint `http://api.apiato.develop/v1/register ` with **cURL**:
 
 ```shell
-curl -X POST -H "Accept: application/json" -H "Cache-Control: no-cache" -F "email=mahmoud@zalt.me" -F "password=so-secret" -F "name=Mahmoud Zalt" "http://api.apiato.dev/v1/register"
+curl -X POST -H "Accept: application/json" -H "Cache-Control: no-cache" -F "email=mahmoud@zalt.me" -F "password=so-secret" -F "name=Mahmoud Zalt" "http://api.apiato.develop/v1/register"
 ```
 
-You should get response similar to this:
+You should get response like this:
 
 ```json
 Access-Control-Allow-Origin → ...

--- a/_docs/getting-started/overview.md
+++ b/_docs/getting-started/overview.md
@@ -11,7 +11,6 @@ order: 3
   * [Sample Action](#sample-action)
   * [Sample User Response](#user-res)
 
-
 <a name="Quick-Overview"></a>
 ## Quick Overview
 
@@ -19,6 +18,7 @@ order: 3
 ### The basic flow
 
 When an HTTP request is received, it first hits your predefined Endpoint (each endpoint live in its own Route file).
+
 <a name="sample-route"></a>
 #### Sample Route Endpoint
 
@@ -29,7 +29,9 @@ $router->get('hello', [
 ]);
 ```
 
-After the user makes a request to the endpoint `[GET] www.api.apiato.com/v1/hello` it calls the defined controller function (`sayHello`).
+After the user makes a request to the endpoint `[GET] www.api.apiato.com/v1/hello` it calls the defined controller 
+function (`sayHello`).
+
 <a name="control-fun"></a>
 #### Sample Controller Function
 
@@ -48,9 +50,11 @@ class Controller extends ApiController
 }
 ```
 
-This function takes a Request class `SayHelloRequest` to automatically checks if the user has the right access to this endpoint. _Only if the user has access, it proceed to the function body._
+This function takes a Request class `SayHelloRequest` to automatically checks if the user has the right access to this 
+endpoint. _Only if the user has access, it proceed to the function body._
 
 Then the function calls an Action (`SayHelloAction`) to perform the business logic.
+
 <a name="sample-action"></a>
 #### Sample Action
 
@@ -67,9 +71,10 @@ class SayHelloAction extends Action
 
 The Action can do anything then return a result (could be Object, String or anything).
 
-When the Action finish its job the controller function gets ready to build a response.
+When the Action finishes its job, the controller function gets ready to build a response.
 
 Json responses can be built using the helper function `json` (`$this->json(['foo' => 'bar']);`).
+
 <a name="user-res"></a>
 #### Sample User Response
 

--- a/_docs/getting-started/requests.md
+++ b/_docs/getting-started/requests.md
@@ -10,26 +10,24 @@ order: 4
   * [Calling unprotected endpoint example](#call-unprotected-EP)
   * [Calling protected endpoint (passing Bearer Token) example](#call-protected-EP)
 
-
-<br>
-
 <a name="form-content-types"></a>
 ## Form content types (W3C)
 
-By default Apiato is configured to encode simple text/ASCII data `x-www-form-urlencoded`. However, it does support other types as well. 
-
+By default Apiato is configured to encode simple text/ASCII data `x-www-form-urlencoded`. However, it does support 
+other types as well. 
 
 #### ASCII payload
 
-To tell the web server that you are posting simple text/ASCII payload (`name=Mahmoud+Zalt&age=18`), you need to include `Content-Type = x-www-form-urlencoded` in the request header.
+To tell the web server that you are posting simple text/ASCII payload (`name=Mahmoud+Zalt&age=18`), you need to include 
+`Content-Type : x-www-form-urlencoded` in the request header.
 
 #### JSON payload
 
-To tell the web server that you are posting JSON-formatted payload (`{name : 'Mahmoud Zalt', age: 18}`), you need to include `Content-Type = application/json` in the request header.
+To tell the web server that you are posting JSON-formatted payload (`{name : 'Mahmoud Zalt', age: 18}`), you need to 
+include `Content-Type = application/json` in the request header.
 
-*(you may wish return Json data in this case as well, you can do so by changing the response serializer from `DataArraySerializer` to `JsonApiSerializer`, more about that in the response page).*
-
-
+*(you may wish return Json data in this case as well, you can do so by changing the response serializer from 
+`DataArraySerializer` to `JsonApiSerializer`, more about that in the response page).*
 
 <a name="send-http-req"></a>
 ## HTTP Request Headers
@@ -42,22 +40,26 @@ To tell the web server that you are posting JSON-formatted payload (`{name : 'Ma
 | If-None-Match | `811b22676b6a4a0489c920073c0df914`  | MAY be sent to indicate a specific **ETag** of an prior Request to this Endpoint. If both ETags match (i.e., are the same) a HTTP 304 (not modified) is returned. |
 
 
-> Normally you should include the `Accept => application/json` HTTP header when you call a JSON API.
-However, in Apiato you can force your users to send `application/json` by setting `'force-accept-header' => true,` in `app/Ship/Configs/apiato.php`
-Or allow them to skip it by setting the `'force-accept-header' => false,` (By default this is set to false).
-
+> #### Heads Up!
+> 
+> Normally you should include the `Accept : application/json` HTTP header when you call a JSON API. However, in Apiato 
+> you can force your users to send `application/json` by setting `'force-accept-header' => true,` in 
+> `app/Ship/Configs/apiato.php` or allow them to skip it completely by setting the `'force-accept-header' => false,`. 
+> By default this flag is set to false.
 
 <a name="call-EP"></a>
 ## Calling Endpoints
+
 <a name="call-unprotected-EP"></a>
 ### Calling unprotected endpoint example:
 
 ```shell
-curl -X POST -H "Accept: application/json" -H "Content-Type: application/x-www-form-urlencoded; -F "email=admin@admin.com" -F "password=admin" -F "=" "http://api.domain.dev/v2/register"
+curl -X POST -H "Accept: application/json" -H "Content-Type: application/x-www-form-urlencoded; -F "email=admin@admin.com" -F "password=admin" -F "=" "http://api.domain.develop/v2/register"
 ```
+
 <a name="call-protected-EP"></a>
 ### Calling protected endpoint (passing Bearer Token) example:
 
 ```shell
-curl -X GET -H "Accept: application/json" -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..." -H "http://api.domain.dev/v1/users"
+curl -X GET -H "Accept: application/json" -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..." -H "http://api.domain.develop/v1/users"
 ```

--- a/_docs/getting-started/responses.md
+++ b/_docs/getting-started/responses.md
@@ -4,7 +4,6 @@ category: "Getting Started"
 order: 5
 ---
 
-
 * [Apiato Response](#Res-payload)
 * [Default Apiato Responses Payload](#Def-Res-payload)
 * [Change the default Response payload](#change-apiao-res-payload)
@@ -12,21 +11,20 @@ order: 5
 * [Error Responses formats](#Error-Res-Format)
 * [Building a Responses from the Controller](#build-res-from-con)
 
-
-<br>
-
 <a name="Res-payload"></a>
 ### Apiato Response
 
 In Apiato you can define your own response payload or use one of the supported serializers.
 
-Currently the supported serializers are (`ArraySerializer`, `DataArraySerializer` and `JsonApiSerializer`). As provided by [Fractal](http://fractal.thephpleague.com/transformers/).
+Currently the supported serializers are (`ArraySerializer`, `DataArraySerializer` and `JsonApiSerializer`). As provided 
+by [Fractal](http://fractal.thephpleague.com/transformers/).
 
 By default Apiato uses `DataArraySerializer`. Below is an example of the response payload.
+
 <a name="Def-Res-payload"></a>
 ### Default Apiato Responses Payload:
 
-`DataArraySerializer` Responses Payloads:
+`DataArraySerializer` pesponse payload look like this:
 
 ```json
 {
@@ -60,7 +58,7 @@ By default Apiato uses `DataArraySerializer`. Below is an example of the respons
       "current_page": 999,
       "total_pages": 999,
       "links": {
-        "next": "http://api.apiato.dev/v1/accounts?page=999"
+        "next": "http://api.apiato.develop/v1/accounts?page=999"
       }
     }
   },
@@ -86,7 +84,7 @@ When data is paginated the response payload will contain a `meta` description ab
       "current_page": 999,
       "total_pages": 999,
       "links": {
-        "next": "http://api.apiato.dev/v1/accounts?page=999"
+        "next": "http://api.apiato.develop/v1/accounts?page=999"
       }
     }
   },
@@ -100,8 +98,7 @@ When data is paginated the response payload will contain a `meta` description ab
 
 **Includes:**
 
-Informs the User about what relationships can be include in the response.
-Example: `?include=tags,user`
+Informs the User about what relationships can be include in the response. Example: `?include=tags,user`
 
 For more details read the `Relationships` section in the [Query Parameters]({{ site.baseurl }}{% link _docs/features/query-parameters.md %}) page.
 
@@ -116,9 +113,13 @@ To change the default Fractal Serializer open the `.env` file and change the
 API_RESPONSE_SERIALIZER=League\Fractal\Serializer\DataArraySerializer
 ```
 
-The Supported Serializers are (`ArraySerializer`, `DataArraySerializer` and `JsonApiSerializer`).
+The Supported Serializers are
+* `ArraySerializer`
+* `DataArraySerializer`
+* `JsonApiSerializer`
 
-More details can be found at [Fractal](http://fractal.thephpleague.com/transformers/) and [Laravel Fractal Wrapper](https://github.com/spatie/laravel-fractal).
+More details can be found at [Fractal](http://fractal.thephpleague.com/transformers/) and 
+[Laravel Fractal Wrapper](https://github.com/spatie/laravel-fractal).
 
 In case of returning JSON Data (`JsonApiSerializer`), you may wish to check some JSON response standards:
 
@@ -126,31 +127,30 @@ In case of returning JSON Data (`JsonApiSerializer`), you may wish to check some
 * [JSON API](http://jsonapi.org/format/) (very popular and well documented)
 * [HAL](http://stateless.co/hal_specification.html) (useful in case of hypermedia)
 
-
 <a name="Resource-Keys"></a>
 ### Resource Keys
 
 #### For JsonApiSerializer. 
 
-The transformer allows appending a `ResourceKey` to the transformed resource.
-You can set the `ResourceKey` in your response payload in 2 ways:
+The transformer allows appending a `ResourceKey` to the transformed resource. You can set the `ResourceKey` in your 
+response payload in 2 ways:
 
 1. Manually set it via the respective parameter in the `$this->transform()` call. Note that this will only set the
 `top level` resource key and does not affect the resource keys from `included` resources!
-2. Specify it on the respective `Model`. By overriding the the $resourceKey, (`protected $resourceKey = 'FooBar';`). If no `$resourceKey` is defined at the `Model`, the `ShortClassName` is used as key. For example, the `ShortClassName` of
+2. Specify it on the respective `Model`. By overriding the the $resourceKey, (`protected $resourceKey = 'FooBar';`). 
+If no `$resourceKey` is defined at the `Model`, the `ShortClassName` is used as key. For example, the `ShortClassName` of
 the `App\Containers\User\Models\User::class` is `User`.
 
 #### For DataArraySerializer.
 
-By default the `object` keyword is used as a resource key for each response, and it's set manually in each transformer, *to be automated later*.
-
-
+By default the `object` keyword is used as a resource key for each response, and it's set manually in each transformer, 
+*to be automated later*.
 
 <a name="Error-Res-Format"></a>
 ### Error Responses formats
 
-Visit each feature, example the Authentication and there you will see how an unauthenticated response looks like, same for Authorization, Validation and so on.
-
+Visit each feature, example the Authentication and there you will see how an unauthenticated response looks like, same 
+for Authorization, Validation and so on.
 
 <a name="build-res-from-con"></a>
 ## Building a Responses from the Controller:

--- a/_docs/miscellaneous/container-installer.md
+++ b/_docs/miscellaneous/container-installer.md
@@ -8,7 +8,6 @@ order: 5
   * [Downloading and Installing 3rd Party Containers](#downloading-and-installing-3rdPartyContainers)
   * [Developing a Container](#developing-a-container)
 
-
 <a name="containers"></a>
 ## Containers
 
@@ -37,7 +36,6 @@ For example, the respective `/app/Containers/composer.json` file may look someth
     "johannesschobel/apiato-null" : "dev-master"
   }
 }
-
 ```
 
 You just need to call `composer update` in order to install the respective packages. The package (e.g., the container)

--- a/_docs/miscellaneous/contribution.md
+++ b/_docs/miscellaneous/contribution.md
@@ -4,12 +4,8 @@ category: "Miscellaneous"
 order: 11
 ---
 
-
-
-Thank you for considering to contribute to Apiato. This project is powered and driven by its users. So contributions are **welcome** and will be fully **credited**.
-
-
-
+Thank you for considering to contribute to Apiato. This project is powered and driven by its users. So contributions 
+are **welcome** and will be fully **credited**.
 
 * [Standards and Practices](#Standards-Practices)
     * [Versioning](#Versioning)
@@ -27,7 +23,6 @@ Thank you for considering to contribute to Apiato. This project is powered and d
     * [Documentation](#Contributing-Documentation)
     * [Code Generator](#Contributing-Generator)
 
-
 <a name="Standards-Practices"></a>
 # Standards and Practices
 
@@ -44,8 +39,7 @@ The project is compliant with [PSR-1](https://github.com/php-fig/fig-standards/b
 [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md) Styles.
  
 As well as it is compliant with [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md) Autoloader.
-*If you notice any compliance oversights, you can send a patch via pull request.*
-
+*If you notice any compliance oversights, you can send a pull request to address this issue.*
 
 <a name="Git-Branches"></a>
 ### Git Branches
@@ -96,7 +90,6 @@ A good bug report includes the following sections:
 * Any other information that will help us debug and reproduce the issue, including stack traces, system/environment 
 information, and screenshots
 
-
 <a name="Fixing-Bugs"></a>
 ### Fixing Bugs
 
@@ -132,15 +125,15 @@ Important things to remember when contributing:
 
 If you discover a security vulnerability, please send an email to `mahmoud@zalt.me`.
 
-<br>
-
 ___
 
 <a name="Contributing-Apiato"></a>
 # Contributing to Apiato
 
-> The project consist of 2 repositories `apiato/apiato` (the project skeleton, with default containers) and `apiato/core` (the core package of apiato).
-
+> #### Heads Up!
+> 
+> The project consist of 2 repositories `apiato/apiato` (the project skeleton, with default containers) and 
+`apiato/core` (the core package of apiato).
 
 <a name="Contributing-Skeleton-Project"></a>
 ## Contributing to the Skeleton Project
@@ -160,7 +153,6 @@ In this scenario let's assume we have the following:
 
 * `Apiato`     # is the starter/framework project
 * `Project-A`  # your personal project your building on top of apiato
-
 
 1) Create Project A from Apiato
 
@@ -278,7 +270,8 @@ Checkout [How to upgrade apiato]({{ site.baseurl }}{% link _docs/miscellaneous/f
 
 The Apiato core package, is what provides most of the functionality of the Apiato project. 
 
-This guide will help you contribute to the Apiato core package, while the package is in your vendor directory. Without much effort.
+This guide will help you contribute to the Apiato core package, while the package is in your vendor directory. Without 
+much effort.
 
 ### SETUP
 
@@ -299,9 +292,6 @@ You should now have the `.git` directory of the `core` package (your forked vers
 
 Edit > Commit > Push > PR :)
 
-
-<br>
-
 <a name="Contributing-Documentation"></a>
 ## Contributing to the Documentation
 
@@ -318,8 +308,8 @@ are named as they are in the site menu)*, update or add the text, the commit.
 - The styles are in `main.scss` and `_sass/*`.
 - The Layout `_layouts/default.html`.
 - The docs folders `_docs/*` do not represent the categories displayed in the site. 
-- To add new category for a file `category: "New Category"` (usually defined in each documentation readme).
-you must add the category name to `_config.yml` under `categories-order` in order to appear in the site. 
+- To add new category for a file `category: "New Category"` (usually defined in each documentation readme), you must 
+add the category name to `_config.yml` under `categories-order` in order to appear in the site. 
 - To set a link, use the internal links as follow: `[your-text]( { { site.baseurl } } { % link _docs/path/file.md % } )`. 
 NOTE: remove the spaces between the tags.
 
@@ -351,7 +341,6 @@ The Code generator is part of the `apiato/core` package.
 - Code Path: `/Generator`.
 
 Each component command, "Except the Containers Generator" must extend from the `Apiato\Core\Generator\GeneratorCommand.php`.
-
 This abstract class does all the work for you.
 
 ### Add new component generator.

--- a/_docs/miscellaneous/faq.md
+++ b/_docs/miscellaneous/faq.md
@@ -31,15 +31,15 @@ have the freedom to structure your own project anyway you like, and still use al
 <a name="q2"></a>
 ## How to use my custom domain?
 
-Change the default URL from `apiato.dev` to `awesome.com`
+Change the default URL from `apiato.develop` to `awesome.com`
 
 1) Edit your hosts file `sudo vi ect/hosts`, and map your domain `awesome.com` to the IP address of your Virtual Host 
 (Localhost, Docker IP, Vagrant IP, ...)
 
-2) Edit the `.env` file and replace `apiato.dev` with `awesome.com` in `APP_URL`, and `API_URL` *(note the API domain 
+2) Edit the `.env` file and replace `apiato.develop` with `awesome.com` in `APP_URL`, and `API_URL` *(note the API domain 
 should be api.)*
 
-3) Edit the `phpunit.xml` file and change `API_BASE_URL` from `apiato.dev` to `awesome.com`
+3) Edit the `phpunit.xml` file and change `API_BASE_URL` from `apiato.develop` to `awesome.com`
 
 
 <a name="q3"></a>

--- a/_docs/miscellaneous/magical-call.md
+++ b/_docs/miscellaneous/magical-call.md
@@ -116,7 +116,8 @@ $foo = Apiato::call('Container@ActionOrTask', [], [
 <a name="#transactional-call"></a>
 ### Transactional Magical Call
 
-Sometimes, you want to wrap a call into one `Database Transaction` (see [Laravel Documentation](https://laravel.com/docs/5.6/database#database-transactions)).
+Sometimes, you want to wrap a call into one `Database Transaction` (see 
+[Laravel Documentation](https://laravel.com/docs/5.6/database#database-transactions)).
 
 Consider the following example: You want to create a new `Team` and automatically assign yourself (i.e., your own 
 `User`) to this newly created `Team`. Your `CreateTeamAction` may call a dedicated `CreateTeamTask` and a 

--- a/_docs/miscellaneous/tests-helpers.md
+++ b/_docs/miscellaneous/tests-helpers.md
@@ -64,7 +64,7 @@ class RegisterUserTest extends TestCase
     {
         // prepare your post data
         $data = [
-            'email'    => 'hello@mail.dev',
+            'email'    => 'hello@mail.develop',
             'name'     => 'Mahmoud',
             'password' => 'secret',
         ];
@@ -181,7 +181,7 @@ $response = $this->endpoint('get@item/{id}')->injectId($user->id)->makeCall();
 $user = $this->getTestingUser();
 
 $user = $this->getTestingUser([
-    'email'    => 'hello@mail.dev',
+    'email'    => 'hello@mail.develop',
     'name'     => 'Hello',
     'password' => 'secret',
 ]);

--- a/_docs/miscellaneous/upgrade-guide.md
+++ b/_docs/miscellaneous/upgrade-guide.md
@@ -14,15 +14,13 @@ order: 12
 - [Manual Upgrading Guide](#Manual-Upgrading-Guide)
 - [Upcoming Release Notes](#Upcoming-Release)
 
-<br>
-
 <a name="upgrade-apiato-from-version73To74"></a>
 ## Upgrade from 7.3 to 7.4
 
 > Estimated upgrading time: 30 minutes.
 
-**IMPORTANT NOTE 1** : Before upgrading, please review **all** of your own dependencies, if respective "Laravel 5.6 compatible versions" are 
-already published!
+**IMPORTANT NOTE 1** : Before upgrading, please review **all** of your own dependencies, if respective "Laravel 5.6 
+compatible versions" are already published!
 
 **IMPORTANT NOTE 2** : Before upgrading, please `git commit` all of your changes in order to rollback if something breaks! 
 
@@ -86,7 +84,8 @@ By upgrading to `Apiato 7.0` you can benefit from all the features provided by `
 
 You just have to do the following changes found at the [GitHub Comparison Tool](https://github.com/apiato/apiato/compare/5.0...7.0).
 
-Note: Some of the files are not required to be upgraded. And some of them, can be simply replaced by the new files (copy a file content from the Apiato repository and replace it with your older version).
+Note: Some of the files are not required to be upgraded. And some of them, can be simply replaced by the new files 
+(copy a file content from the Apiato repository and replace it with your older version).
 
 Hint: You can do a git merge and solve the conflicts, if you don't want to manually do the changes commit by commit.
 
@@ -141,9 +140,6 @@ and you will need to update the namespace from `namespace App\Ship\Seeders\Data\
 15) Run your tests `vendor/bin/phpunit`.
 
 That's it :)
-
-
-
 
 <a name="how-to-manually-upgrade-older-versions-to-41"></a>
 ## How to manually upgrade older versions to 4.1?
@@ -261,10 +257,8 @@ composer update && vendor/bin/phpunit
 
 See the [Upcoming Release Notes](#Upcoming-Release) for details about the changes.
 
-
-
-
 <a name="Upcoming-Release"></a>
 ## Upcoming Release Notes
 
-Checkout the [ChangeLog](https://github.com/apiato/apiato/blob/master/CHANGELOG.md) notes, for the upcoming features and changes.
+Checkout the [ChangeLog](https://github.com/apiato/apiato/blob/master/CHANGELOG.md) notes, for the upcoming features 
+and changes.


### PR DESCRIPTION
This PR changes the `.dev` urls to `.develop`.

Major:
* In recent times, `.dev` was announced as a qualified generic top level domain. This may result in problems when setting up your local development machine.. I changed the URLs accordingly to reflect these changes and added respective hint in the `installation` part.
 
Minor:
* changed wording in order to improve readability
* formatting