### PR TITLE
fix: Remove mentions to apiato:permissions:toRole

### DIFF
--- a/docs/core-features/authorization.md
+++ b/docs/core-features/authorization.md
@@ -75,7 +75,7 @@ The Default Super User, has a default role `admin`.
 
 The `admin` default role **has no permissions given to it**.
 
-To give permissions to the `admin` role (or any other role), you can use the dedicated endpoints (from your custom Admin Interface) or use this command `php artisan apiato:permissions:toRole admin` to give it all the permissions in the system.
+To give permissions to the `admin` role (or any other role), you can use the dedicated endpoints (from your custom Admin Interface).
 
 Checkout each container **Seeders** directory `app/Containers/AppSection/{container-name}/Data/Seeders/`, to edit the default **Users**, **Roles** and **Permissions**.
 

--- a/docs/core-features/useful-commands.md
+++ b/docs/core-features/useful-commands.md
@@ -14,7 +14,6 @@ You can see list of all commands, by typing `php artisan` and look for **Apiato*
   - `php artisan apiato:generate:{component}`      Generate a specific component for the framework (e.g., `Action`, `Task`, ...). For more details on the `Code Generator` [click here](../core-features/code-generator).
   - `php artisan apiato:list:actions`              List all Actions in the Application.
   - `php artisan apiato:list:tasks`                List all Tasks in the Application.
-  - `php artisan apiato:permissions:toRole`        Give all system Permissions to a specific Role.
   - `php artisan apiato:seed-deploy`               Seeds your custom deployment data from `app/Ship/Seeders/SeedDeploymentData.php`.
   - `php artisan apiato:seed-test`                 Seeds your custom testing data from `app/Ship/Seeders/SeedTestingData.php`.
   - `php artisan apiato:welcome`                   Just saying welcome from a container.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -79,15 +79,6 @@ php artisan migrate
 php artisan db:seed
 ```
 
-3) Optional. By default, Apiato seeds a "Super User", given the default `admin` role (the role has no Permissions set
-to it).
-
-To give the `admin` role, access to all the seeded permissions in the system, run the following command, at any time.
-
-```
-php artisan apiato:permissions:toRole admin
-```
-
 ### OAuth 2.0 Setup {#Prepare-OAuth}
 
 1) Create encryption keys to generate secure access tokens and create "personal access" and "password grant" clients

--- a/versioned_docs/version-11.x/core-features/authorization.md
+++ b/versioned_docs/version-11.x/core-features/authorization.md
@@ -75,7 +75,7 @@ The Default Super User, has a default role `admin`.
 
 The `admin` default role **has no permissions given to it**.
 
-To give permissions to the `admin` role (or any other role), you can use the dedicated endpoints (from your custom Admin Interface) or use this command `php artisan apiato:permissions:toRole admin` to give it all the permissions in the system.
+To give permissions to the `admin` role (or any other role), you can use the dedicated endpoints (from your custom Admin Interface).
 
 Checkout each container **Seeders** directory `app/Containers/AppSection/{container-name}/Data/Seeders/`, to edit the default **Users**, **Roles** and **Permissions**.
 

--- a/versioned_docs/version-11.x/core-features/useful-commands.md
+++ b/versioned_docs/version-11.x/core-features/useful-commands.md
@@ -14,7 +14,6 @@ You can see list of all commands, by typing `php artisan` and look for **Apiato*
   - `php artisan apiato:generate:{component}`      Generate a specific component for the framework (e.g., `Action`, `Task`, ...). For more details on the `Code Generator` [click here](../core-features/code-generator).
   - `php artisan apiato:list:actions`              List all Actions in the Application.
   - `php artisan apiato:list:tasks`                List all Tasks in the Application.
-  - `php artisan apiato:permissions:toRole`        Give all system Permissions to a specific Role.
   - `php artisan apiato:seed-deploy`               Seeds your custom deployment data from `app/Ship/Seeders/SeedDeploymentData.php`.
   - `php artisan apiato:seed-test`                 Seeds your custom testing data from `app/Ship/Seeders/SeedTestingData.php`.
   - `php artisan apiato:welcome`                   Just saying welcome from a container.

--- a/versioned_docs/version-11.x/getting-started/installation.md
+++ b/versioned_docs/version-11.x/getting-started/installation.md
@@ -79,15 +79,6 @@ php artisan migrate
 php artisan db:seed
 ```
 
-3) Optional. By default, Apiato seeds a "Super User", given the default `admin` role (the role has no Permissions set
-to it).
-
-To give the `admin` role, access to all the seeded permissions in the system, run the following command, at any time.
-
-```
-php artisan apiato:permissions:toRole admin
-```
-
 ### OAuth 2.0 Setup {#Prepare-OAuth}
 
 1) Create encryption keys to generate secure access tokens and create "personal access" and "password grant" clients


### PR DESCRIPTION
[v11](https://github.com/apiato/apiato/releases/tag/v11.0.0) got rid of the `apiato:permissions:toRole`, and this commit removes it from the documentation.

Fix #61